### PR TITLE
Support pre measued times

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,13 @@ Timing
     timer.intermediate('second-pass')
     timer.stop()
 
+When you have end up with a measurement from somewhere else, perhaps from an external service, you can also send that, using the ``.send`` function on the timer class, in fact this is what the higler level functions above use, behind the scenes.
+
+.. code-block:: python
+
+    timer = my_client.timer('my-timer-name')
+    timer.send('db-call', 12.5)
+
 Counting
 --------
 

--- a/charcoal/client.py
+++ b/charcoal/client.py
@@ -73,8 +73,8 @@ class Timer:
         self._start = None
         self._intermediate = None
 
-    def _send(self, name, value):
-        """Send a timer off."""
+    def send(self, name, value):
+        """Send a measured time off."""
         self.client.send(
             *packets.timer_packet(
                 dot_join(self.suffix, name),
@@ -90,18 +90,14 @@ class Timer:
     def intermediate(self, name):
         """Send an intermediate time."""
         since = self._intermediate or self._start
-        self._send(name, time.time() - since)
+        self.send(name, time.time() - since)
         self._intermediate = time.time()
 
     def stop(self, name='total'):
         """Stop the timer."""
-        self._send(name, time.time() - self._start)
+        self.send(name, time.time() - self._start)
         self._start = None
         self._intermediate = None
-
-    def raw(self, name, pre_measured_time):
-        """Send a pre-measured time."""
-        self._send(name, pre_measured_time)
 
 
 class Counter:

--- a/charcoal/client.py
+++ b/charcoal/client.py
@@ -99,6 +99,10 @@ class Timer:
         self._start = None
         self._intermediate = None
 
+    def raw(self, name, pre_measured_time):
+        """Send a pre-measured time."""
+        self._send(name, pre_measured_time)
+
 
 class Counter:
     """Counter class.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -50,12 +50,12 @@ def test_timer_reuse(client, listener):
     ]
 
 
-def test_timer_raw(client, listener):
+def test_timer_manual_measurements(client, listener):
     """Test that the timer supports premeasured times."""
     timer = client.timer('mytimer')
 
-    timer.raw('something', 10)
-    timer.raw('something', 15)
+    timer.send('something', 10)
+    timer.send('something', 15)
 
     assert list(listener.load_received()) == [
         b'mystats.mytimer.something:10000|ms',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -50,6 +50,19 @@ def test_timer_reuse(client, listener):
     ]
 
 
+def test_timer_raw(client, listener):
+    """Test that the timer supports premeasured times."""
+    timer = client.timer('mytimer')
+
+    timer.raw('something', 10)
+    timer.raw('something', 15)
+
+    assert list(listener.load_received()) == [
+        b'mystats.mytimer.something:10000|ms',
+        b'mystats.mytimer.something:15000|ms',
+    ]
+
+
 def test_counter(client, listener):
     """Test a counter."""
     counter = client.counter('mycounter')


### PR DESCRIPTION
Sometimes you receive a number representing how long something took, such as a search request on Elasticsearch (something I personally know a bit), and those would be nice to be able to measure as well. Currently the `Timer` class is unable to handle that, and while you could work it with the `.send` function on the client, but I think that is too low level for something that is common enough to support it.
- [x] Find the right name for the function, `.raw` is perhaps not the best.
